### PR TITLE
OFAST-66 Lesson URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import LoginPage from './pages/LoginPage'
 import HomePage from './pages/HomePage'
 import AboutPage from './pages/AboutPage'
 import LearnPage from './pages/LearnPage'
+import LessonPage from './pages/LessonPage'
 import NavBar from './pages/NavBar'
 import SolvePage from './pages/SolvePage'
 
@@ -52,6 +53,7 @@ export function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/learn" element={<LearnPage />} />
+        <Route path="/learn/:lesson" element={<LessonPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/solve" element={<SolvePage />} />
         <Route path="/login" element={<LoginPage />} />

--- a/src/pages/LearnPage.tsx
+++ b/src/pages/LearnPage.tsx
@@ -99,9 +99,7 @@ const lessons: lesson[] = [
 ]
 
 export default function LearnPage() {
-  const groupedLessons: {
-    [key: string]: lesson[]
-  } = {}
+  const groupedLessons: Record<string, lesson[]> = {}
 
   lessons.forEach((lesson) => {
     if (!(lesson.group in groupedLessons)) {

--- a/src/pages/LearnPage.tsx
+++ b/src/pages/LearnPage.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useState } from 'react'
 import {
   Box,
   Container,
@@ -13,11 +12,7 @@ import { styled } from '@mui/material/styles'
 
 import SearchBar from '../components/SearchBar'
 import InlineSpacing from '../components/InlineSpacing'
-import ReadingBlock from '../components/ReadingBlock'
-import LessonPage from './LessonPage'
-import MCQBlock from '../components/MCQBlock'
-import FITBBlock from '../components/FITBBlock'
-import fetchLessonContent from '../functions/FetchLessonContent'
+import { Link } from 'react-router-dom'
 
 const LessonButton = styled(Button)({
   border: '1px solid',
@@ -64,25 +59,59 @@ function LessonGroup({ title, children }: LessonGroupProps) {
   )
 }
 
-const dp = await fetchLessonContent('dynamic_programming/lesson.md')
-const markdown1 = await fetchLessonContent('dynamic_programming/markdown1.md')
-const markdown2 = await fetchLessonContent('dynamic_programming/markdown2.md')
-const markdown3 = await fetchLessonContent('dynamic_programming/markdown3.md')
+interface lesson {
+  group: string
+  name: string
+  urlParam: string
+}
 
-const q1 =
-  'Which of the problems below can be solved effectively using dynamic programming.'
-const ans1 = ['Coin denomination', 'Knapsack Problem', 'Sorting List']
-const correct1 = ['Coin denomination', 'Knapsack Problem']
-
-const q2 =
-  'In dynamic programming, what is the key characteristic that distinguishes it from other algorithmic approaches?'
-const ans2 = ['Recursion', 'Iteration', 'Memoization']
-const correct2 = ['Memoization']
+const lessons: lesson[] = [
+  {
+    group: 'Intro Algo Design',
+    name: 'Brute Force',
+    urlParam: 'dp',
+  },
+  {
+    group: 'Intro Algo Design',
+    name: 'Intro Greedy',
+    urlParam: 'greedy',
+  },
+  {
+    group: 'Intro Algo Design',
+    name: 'Time & Memory Analysis',
+    urlParam: 'dp',
+  },
+  {
+    group: 'Intro Data Structures',
+    name: 'Prefix Sums',
+    urlParam: 'dp',
+  },
+  {
+    group: 'Intro Data Structures',
+    name: 'Lists & Vectors',
+    urlParam: 'dp',
+  },
+  {
+    group: 'Intro Data Structures',
+    name: 'Stacks & Queues',
+    urlParam: 'dp',
+  },
+]
 
 export default function LearnPage() {
-  const [lesson, setLesson] = useState<React.ReactNode>(null)
+  const groupedLessons: {
+    [key: string]: lesson[]
+  } = {}
 
-  return !lesson ? (
+  lessons.forEach((lesson) => {
+    if (!(lesson.group in groupedLessons)) {
+      groupedLessons[lesson.group] = []
+    }
+
+    groupedLessons[lesson.group].push(lesson)
+  })
+
+  return (
     <Container sx={{ p: 15 }}>
       <Typography variant="h3" gutterBottom color="primary">
         Learn
@@ -90,75 +119,34 @@ export default function LearnPage() {
 
       <SearchBar />
 
-      <LessonGroup title="Intro Algo Design">
-        <InlineSpacing spacing={40} />
+      {Object.entries(groupedLessons).map((lessonGroup, groupIndex) => {
+        return (
+          <>
+            <LessonGroup title={lessonGroup[0].toString()}>
+              <InlineSpacing spacing={40} />
+              {lessonGroup[1].map((lesson) => (
+                <>
+                  <LessonButton>
+                    <Link
+                      style={{ color: 'inherit', textDecoration: 'none' }}
+                      to={'/learn/' + lesson.urlParam}
+                    >
+                      {lesson.name}
+                    </Link>
+                  </LessonButton>
+                  <InlineSpacing spacing={60} />
+                </>
+              ))}
 
-        <LessonButton
-          onClick={() =>
-            setLesson(
-              <LessonPage
-                blocks={[
-                  <ReadingBlock content={dp} />,
-                  <MCQBlock
-                    question={q1}
-                    answerOptions={ans1}
-                    correctOptions={correct1}
-                  />,
-                  <MCQBlock
-                    question={q2}
-                    answerOptions={ans2}
-                    correctOptions={correct2}
-                  />,
-                  <FITBBlock
-                    question={
-                      'Is this the real life? Is this just {fantasy}? ' +
-                      'Caught in a {landslide}, no escape from reality. ' +
-                      'Open your eyes, look up to the {skies} and see...'
-                    }
-                  />,
-                  <ReadingBlock content={markdown1} />,
-                  <ReadingBlock content={markdown2} />,
-                  <ReadingBlock content={markdown3} />,
-                ]}
-              />,
-            )
-          }
-        >
-          Brute Force
-        </LessonButton>
+              <NextButton>
+                <ArrowForwardIcon style={{ fontSize: '3rem' }} />
+              </NextButton>
+            </LessonGroup>
 
-        <InlineSpacing spacing={60} />
-
-        <LessonButton>Intro Greedy</LessonButton>
-
-        <InlineSpacing spacing={60} />
-
-        <LessonButton>Time & Memory Analysis</LessonButton>
-      </LessonGroup>
-
-      <Divider />
-
-      <LessonGroup title="Intro Data Structures">
-        <InlineSpacing spacing={40} />
-
-        <LessonButton>Prefix Sums</LessonButton>
-
-        <InlineSpacing spacing={60} />
-
-        <LessonButton>Lists & Vectors</LessonButton>
-
-        <InlineSpacing spacing={60} />
-
-        <LessonButton>Stacks & Queues</LessonButton>
-
-        <InlineSpacing spacing={40} />
-
-        <NextButton>
-          <ArrowForwardIcon style={{ fontSize: '3rem' }} />
-        </NextButton>
-      </LessonGroup>
+            {groupIndex + 1 < Object.entries(groupedLessons).length && <Divider />}
+          </>
+        )
+      })}
     </Container>
-  ) : (
-    lesson
   )
 }

--- a/src/pages/LearnPage.tsx
+++ b/src/pages/LearnPage.tsx
@@ -143,7 +143,9 @@ export default function LearnPage() {
               </NextButton>
             </LessonGroup>
 
-            {groupIndex + 1 < Object.entries(groupedLessons).length && <Divider />}
+            {groupIndex + 1 < Object.entries(groupedLessons).length && (
+              <Divider />
+            )}
           </>
         )
       })}

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -3,9 +3,13 @@ import { Box, Container } from '@mui/material'
 
 import './LessonPage.css'
 
-interface LessonPageProps {
-  blocks: ReadonlyArray<React.ReactNode>
-}
+import { useParams, Navigate } from 'react-router-dom'
+
+import ReadingBlock from '../components/ReadingBlock'
+import MCQBlock from '../components/MCQBlock'
+import FITBBlock from '../components/FITBBlock'
+
+import fetchLessonContent from '../functions/FetchLessonContent'
 
 function getWindowDimensions() {
   const { innerWidth: width, innerHeight: height } = window
@@ -74,7 +78,53 @@ function LessonBlockWrapper({
   )
 }
 
-export default function LessonPage({ blocks }: LessonPageProps) {
+const dp = await fetchLessonContent('dynamic_programming/lesson.md')
+const markdown1 = await fetchLessonContent('dynamic_programming/markdown1.md')
+const markdown2 = await fetchLessonContent('dynamic_programming/markdown2.md')
+const markdown3 = await fetchLessonContent('dynamic_programming/markdown3.md')
+
+const q1 =
+  'Which of the problems below can be solved effectively using dynamic programming.'
+const ans1 = ['Coin denomination', 'Knapsack Problem', 'Sorting List']
+const correct1 = ['Coin denomination', 'Knapsack Problem']
+
+const q2 =
+  'In dynamic programming, what is the key characteristic that distinguishes it from other algorithmic approaches?'
+const ans2 = ['Recursion', 'Iteration', 'Memoization']
+const correct2 = ['Memoization']
+
+const lessons = {
+  dp: [
+    <ReadingBlock content={dp} />,
+    <MCQBlock question={q1} answerOptions={ans1} correctOptions={correct1} />,
+    <MCQBlock question={q2} answerOptions={ans2} correctOptions={correct2} />,
+    <FITBBlock
+      question={
+        'Is this the real life? Is this just {fantasy}? ' +
+        'Caught in a {landslide}, no escape from reality. ' +
+        'Open your eyes, look up to the {skies} and see...'
+      }
+    />,
+    <ReadingBlock content={markdown1} />,
+    <ReadingBlock content={markdown2} />,
+    <ReadingBlock content={markdown3} />,
+  ],
+  greedy: [
+    <ReadingBlock content={`# Welcome to Greedy \n Let's get started`} />,
+    <ReadingBlock content={markdown1} />,
+    <ReadingBlock content={markdown2} />,
+    <ReadingBlock content={markdown3} />,
+  ],
+}
+
+export default function LessonPage() {
+  const params = useParams()
+
+  if (!params.lesson || !(params.lesson in lessons)) {
+    return <Navigate to="/learn" replace={true} />
+  }
+
+  const blocks = lessons[params.lesson]
   const blockRefs = useRef(new Array(blocks.length))
   const [offsetY, setOffsetY] = useState(0)
   const [windowDimensions, setWindowDimensions] = useState(


### PR DESCRIPTION
- Lessons now have their own shareable URLs
- E.g. ofast.io/learn/dp
- Added a test greedy lesson at ofast.io/learn/greedy
- Restructured the way lesson buttons are rendered in the learn page:
  - Buttons are dynamically generated from a list of lessons
  - The learn page's buttons each have a URL parameter associated with them that redirects them to the lesson page
  - Depending on the URL parameter, the lesson page displays the corresponding lesson content


https://github.com/ofast-team/ofast/assets/46213673/4b11b891-bf3f-4a5e-a42a-efb725f5a95a

