### PR TITLE
Fix redux persist non-serializable value

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit'
 import userReducer from './userSlice'
 import { combineReducers } from 'redux'
-import { persistReducer } from 'redux-persist'
+import {
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
 
 const reducers = combineReducers({
@@ -17,6 +25,12 @@ const persistedReducer = persistReducer(persistConfig, reducers)
 
 export const store = configureStore({
   reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
 })
 
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
Redux persist was throwing an error saying a non-serializable value was detected. From some research, this looks normal when using persist. It was just missing some ignored actions for the serializable check, which this PR adds in.

The error:
![image](https://github.com/ofast-team/frontend/assets/46213673/5c6396ca-3bc5-436b-ac3d-00dd4744e323)
