### PR TITLE
Change API request method back to POST

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -70,7 +70,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     fetch(buildPath('/getUserData'), {
-      method: 'GET',
+      method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ uid: user.id }),
     })


### PR DESCRIPTION
I used the GET method in my original PR, but Tyler and I decided to use POST, because we don't want people to access the database with just a URL.

Profile Page is working again,
![image](https://github.com/ofast-team/frontend/assets/51721851/84594d69-75ec-4b37-95fb-8b40753e6646)
