### PR TITLE
OFAST-113 Inline Code Highlight

### DIFF
--- a/src/components/MDXRenderer.tsx
+++ b/src/components/MDXRenderer.tsx
@@ -93,6 +93,7 @@ export default function MDX({ path, value }: MarkdownRendererProps) {
     MDX,
     FITBBlock,
     FITBBlank,
+    code,
   }
 
   const [mdxContent, setMdxContent] = useState<JSX.Element | null>(null)
@@ -124,7 +125,7 @@ export default function MDX({ path, value }: MarkdownRendererProps) {
           jsxs,
           baseUrl: import.meta.url,
         })
-        setMdxContent(res.default({ components: { code, ...components } }))
+        setMdxContent(res.default({ components }))
       } catch (e) {
         setMdxContent(
           <Alert severity="error">{'MDX Compile Error: ' + e.message}</Alert>,

--- a/src/components/MDXRenderer.tsx
+++ b/src/components/MDXRenderer.tsx
@@ -28,7 +28,7 @@ function code(props) {
         className={className}
         style={{
           borderRadius: '5px',
-          backgroundColor: '#DAFFFB',
+          backgroundColor: '#dae5ed',
           paddingLeft: '5px',
           paddingRight: '5px',
         }}

--- a/src/components/MDXRenderer.tsx
+++ b/src/components/MDXRenderer.tsx
@@ -19,6 +19,25 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 function code(props) {
   const [tooltip, setTooltip] = useState<string>('Copy to clipboard')
   const { children, className, ...rest } = props
+
+  // Inline code blocks (single backticks)
+  if (!className) {
+    return (
+      <code
+        {...rest}
+        className={className}
+        style={{
+          borderRadius: '5px',
+          backgroundColor: '#DAFFFB',
+          paddingLeft: '5px',
+          paddingRight: '5px',
+        }}
+      >
+        {children}
+      </code>
+    )
+  }
+
   const match = /language-(\w+)/.exec(className || '')
 
   if (!match) {

--- a/src/components/MDXRenderer.tsx
+++ b/src/components/MDXRenderer.tsx
@@ -25,7 +25,6 @@ function code(props) {
     return (
       <code
         {...rest}
-        className={className}
         style={{
           borderRadius: '5px',
           backgroundColor: '#dae5ed',


### PR DESCRIPTION
Added some highlighting for inline code blocks (single backticks)

|Before|After|
|-|-|
|![image](https://github.com/ofast-team/frontend/assets/46213673/24ae7ce1-3cf7-4b69-a30e-dcb3603c5ed8)|![image](https://github.com/ofast-team/frontend/assets/46213673/cbec97d1-d857-4168-a9ae-d5f816be694f)|