### PR TITLE
FITB Reset and Report

### DIFF
--- a/src/components/FITBBlank.tsx
+++ b/src/components/FITBBlank.tsx
@@ -78,8 +78,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
   useEffect(() => {
     if (guid === '') {
       setGuid(uuidv4())
-    }
-    else {
+    } else {
       fitbState.setBlankStatus(guid, stringsAreEqual(curAnswer, correctAnswer))
     }
   }, [curAnswer, numResets, fitbState])

--- a/src/components/FITBBlank.tsx
+++ b/src/components/FITBBlank.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useEffect, useState } from 'react'
 
 import { FITBContext, FITBState } from './FITBBlock'
 
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from 'uuid'
 
 // removes spaces, and checks for equality ignoring caps
 function stringsAreEqual(a: string, b: string): boolean {
@@ -88,6 +88,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
     setNumResets(fitbState.numResets)
   }
 
+  // Every render, send status back up to the parent
   if (guid !== '') {
     fitbState.setBlankStatus(guid, stringsAreEqual(curAnswer, correctAnswer))
   }
@@ -95,7 +96,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
   const handleChange = (curText: string) => {
     setCurAnswer(curText)
   }
-  
+
   if (fitbState.showAnswer) {
     return (
       <ShowAnswerBlank
@@ -117,7 +118,9 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
     return stringsAreEqual(curAnswer, correctAnswer) ? (
       <CorrectBlank
         variant="standard"
-        onChange={(e) => {handleChange(e.target.value)}}
+        onChange={(e) => {
+          handleChange(e.target.value)
+        }}
         value={curAnswer}
         sx={{
           position: 'relative',
@@ -134,7 +137,9 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
     ) : (
       <IncorrectBlank
         variant="standard"
-        onChange={(e) => {handleChange(e.target.value)}}
+        onChange={(e) => {
+          handleChange(e.target.value)
+        }}
         value={curAnswer}
         sx={{
           position: 'relative',
@@ -154,7 +159,9 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
   return (
     <TextField
       variant="standard"
-      onChange={(e) => {handleChange(e.target.value)}}
+      onChange={(e) => {
+        handleChange(e.target.value)
+      }}
       value={curAnswer}
       sx={{
         position: 'relative',

--- a/src/components/FITBBlank.tsx
+++ b/src/components/FITBBlank.tsx
@@ -1,7 +1,9 @@
 import { TextField, styled } from '@mui/material'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 
 import { FITBContext, FITBState } from './FITBBlock'
+
+import { v4 as uuidv4 } from 'uuid';
 
 // removes spaces, and checks for equality ignoring caps
 function stringsAreEqual(a: string, b: string): boolean {
@@ -70,15 +72,30 @@ interface BlankProps {
 export default function FITBBlank({ correctAnswer }: BlankProps) {
   const fitbState: FITBState = useContext<FITBState>(FITBContext)
   const [curAnswer, setCurAnswer] = useState('')
-  const [counter, setCounter] = useState(0)
+  const [numResets, setNumResets] = useState(0)
+  const [guid, setGuid] = useState<string>('')
 
-  if (fitbState.counter > counter) {
+  // Set the guid if this is the first time rendering
+  useEffect(() => {
+    if (guid === '') {
+      setGuid(uuidv4())
+    }
+  }, [])
+
+  // Clear the blanks if the user just reset.
+  if (fitbState.numResets > numResets) {
     setCurAnswer('')
-    setCounter(fitbState.counter)
-    console.log(counter)
+    setNumResets(fitbState.numResets)
+  }
+
+  if (guid !== '') {
+    fitbState.setBlankStatus(guid, stringsAreEqual(curAnswer, correctAnswer))
+  }
+
+  const handleChange = (curText: string) => {
+    setCurAnswer(curText)
   }
   
-
   if (fitbState.showAnswer) {
     return (
       <ShowAnswerBlank
@@ -100,7 +117,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
     return stringsAreEqual(curAnswer, correctAnswer) ? (
       <CorrectBlank
         variant="standard"
-        onChange={(e) => setCurAnswer(e.target.value)}
+        onChange={(e) => {handleChange(e.target.value)}}
         value={curAnswer}
         sx={{
           position: 'relative',
@@ -117,7 +134,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
     ) : (
       <IncorrectBlank
         variant="standard"
-        onChange={(e) => setCurAnswer(e.target.value)}
+        onChange={(e) => {handleChange(e.target.value)}}
         value={curAnswer}
         sx={{
           position: 'relative',
@@ -137,7 +154,7 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
   return (
     <TextField
       variant="standard"
-      onChange={(e) => setCurAnswer(e.target.value)}
+      onChange={(e) => {handleChange(e.target.value)}}
       value={curAnswer}
       sx={{
         position: 'relative',

--- a/src/components/FITBBlank.tsx
+++ b/src/components/FITBBlank.tsx
@@ -75,22 +75,19 @@ export default function FITBBlank({ correctAnswer }: BlankProps) {
   const [numResets, setNumResets] = useState(0)
   const [guid, setGuid] = useState<string>('')
 
-  // Set the guid if this is the first time rendering
   useEffect(() => {
     if (guid === '') {
       setGuid(uuidv4())
     }
-  }, [])
+    else {
+      fitbState.setBlankStatus(guid, stringsAreEqual(curAnswer, correctAnswer))
+    }
+  }, [curAnswer, numResets, fitbState])
 
   // Clear the blanks if the user just reset.
   if (fitbState.numResets > numResets) {
     setCurAnswer('')
     setNumResets(fitbState.numResets)
-  }
-
-  // Every render, send status back up to the parent
-  if (guid !== '') {
-    fitbState.setBlankStatus(guid, stringsAreEqual(curAnswer, correctAnswer))
   }
 
   const handleChange = (curText: string) => {

--- a/src/components/FITBBlank.tsx
+++ b/src/components/FITBBlank.tsx
@@ -70,6 +70,14 @@ interface BlankProps {
 export default function FITBBlank({ correctAnswer }: BlankProps) {
   const fitbState: FITBState = useContext<FITBState>(FITBContext)
   const [curAnswer, setCurAnswer] = useState('')
+  const [counter, setCounter] = useState(0)
+
+  if (fitbState.counter > counter) {
+    setCurAnswer('')
+    setCounter(fitbState.counter)
+    console.log(counter)
+  }
+  
 
   if (fitbState.showAnswer) {
     return (

--- a/src/components/FITBBlock.tsx
+++ b/src/components/FITBBlock.tsx
@@ -15,10 +15,10 @@ interface HeaderProps {
   setShowHint: Dispatch<SetStateAction<boolean>>
   handleReset: () => void
   handleShowAnswer: () => void
-  setBlankStatus: (uuid: string, correct: boolean) => void 
+  setBlankStatus: (uuid: string, correct: boolean) => void
 }
 
-function Header({ setShowHint, handleShowAnswer, handleReset}: HeaderProps) {
+function Header({ setShowHint, handleShowAnswer, handleReset }: HeaderProps) {
   return (
     <Box
       sx={{
@@ -49,15 +49,17 @@ function Header({ setShowHint, handleShowAnswer, handleReset}: HeaderProps) {
   )
 }
 
+// Store each blank and its status.
 type HashMap = {
-  [uuid: string]: boolean;
-};
+  [uuid: string]: boolean
+}
 
 interface FITBBlockProps {
   hint: string
   children: ReactNode
 }
 
+// This data will be passed down to the blanks
 export interface FITBState {
   submitted: boolean
   showAnswer: boolean
@@ -69,29 +71,25 @@ export const FITBContext = createContext<FITBState>({
   submitted: false,
   showAnswer: false,
   numResets: 0,
-  setBlankStatus: () => {}
-} as FITBState)
+  setBlankStatus: () => {},
+})
 
 export default function FITBBlock({ hint, children }: FITBBlockProps) {
-
-  const [blanks, setBlanks] = useState<object>({})
+  const [blanks, setBlanks] = useState<HashMap>({})
 
   const setBlankStatus = (uuid: string, correct: boolean) => {
-    console.log(uuid + ": " + correct)
     setBlanks((oldData: HashMap) => {
-      const newBlanks = {...oldData, [uuid]: correct}
-      for (const i in newBlanks) {
-        console.log("[" + i + "]:  " + newBlanks[i])
-      }
-      return newBlanks
+      return { ...oldData, [uuid]: correct }
     })
   }
 
-  // only for the state we're passing down to the blanks
-  const defaultFitbState: FITBState = { submitted: false, showAnswer: false, numResets: 0, setBlankStatus: setBlankStatus }
+  const defaultFitbState: FITBState = {
+    submitted: false,
+    showAnswer: false,
+    numResets: 0,
+    setBlankStatus: setBlankStatus,
+  }
   const [fitbState, setFitbState] = useState<FITBState>(defaultFitbState)
-  
-  // everything else
   const [showHint, setShowHint] = useState<boolean>(false)
 
   const handleReset = () => {
@@ -108,8 +106,7 @@ export default function FITBBlock({ hint, children }: FITBBlockProps) {
   }
 
   const allCorrect = () => {
-    console.log(blanks)
-    return Object.values(blanks).every(blank => blank === true)
+    return Object.values(blanks).every((blank) => blank === true)
   }
 
   return (
@@ -125,7 +122,7 @@ export default function FITBBlock({ hint, children }: FITBBlockProps) {
           {children}
         </FITBContext.Provider>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
-          {!fitbState.submitted || (fitbState.submitted && allCorrect()) ? 
+          {!fitbState.submitted || (fitbState.submitted && allCorrect()) ? (
             <Button
               variant="contained"
               onClick={() => {
@@ -133,11 +130,13 @@ export default function FITBBlock({ hint, children }: FITBBlockProps) {
                   return { ...oldData, submitted: true }
                 })
               }}
-              disabled={fitbState.showAnswer || (fitbState.submitted && allCorrect())}
+              disabled={
+                fitbState.showAnswer || (fitbState.submitted && allCorrect())
+              }
             >
               Submit
             </Button>
-            :
+          ) : (
             <Button
               variant="contained"
               onClick={() => {
@@ -149,15 +148,15 @@ export default function FITBBlock({ hint, children }: FITBBlockProps) {
             >
               Try Again
             </Button>
-          }
-          </Box>
-          {showHint ? (
-            <Typography sx={{ fontSize: '1rem' }}>
-              <MDX value={hint} />
-            </Typography>
-          ) : (
-            <React.Fragment />
           )}
+        </Box>
+        {showHint ? (
+          <Typography sx={{ fontSize: '1rem' }}>
+            <MDX value={hint} />
+          </Typography>
+        ) : (
+          <React.Fragment />
+        )}
       </Box>
     </Paper>
   )

--- a/src/components/FITBBlock.tsx
+++ b/src/components/FITBBlock.tsx
@@ -56,16 +56,18 @@ interface FITBBlockProps {
 export interface FITBState {
   submitted: boolean
   showAnswer: boolean
+  counter: number
 }
 
 export const FITBContext = createContext<FITBState>({
   submitted: false,
   showAnswer: false,
+  counter: 0,
 })
 
 export default function FITBBlock({ hint, children }: FITBBlockProps) {
   // only for the state we're passing down to the blanks
-  const defaultFitbState: FITBState = { submitted: false, showAnswer: false }
+  const defaultFitbState: FITBState = { submitted: false, showAnswer: false, counter: 0 }
   const [fitbState, setFitbState] = useState<FITBState>(defaultFitbState)
 
   // everything else
@@ -78,6 +80,9 @@ export default function FITBBlock({ hint, children }: FITBBlockProps) {
     })
     setFitbState((oldData: FITBState) => {
       return { ...oldData, showAnswer: false }
+    })
+    setFitbState((oldData: FITBState) => {
+      return {...oldData, counter: oldData.counter + 1}
     })
   }
 


### PR DESCRIPTION
At this point, the FITB should behave completely as intended and I should be able to move on.
(Besides styling, which we might iterate on later in the semester.)

The question now freezes up when all blanks are answered correctly (just like MCQ.) The blanks are also cleared when you reset the question.

Thank you to Cam for coming up with the idea of how to clear the blanks. It's a weird technique but it works and adds minimal code.

For the freezing up functionality, I assigned each blank a uuid when it is first rendered. Whenever the blank is rerendered. its uuid and "correctness" gets sent up to the parent and stored in a "hashmap." The question's behavior depends on whether all the values in the hashmap are set to true.

https://github.com/ofast-team/frontend/assets/51721851/06e58ca0-7fd4-431a-817c-f05fed758977

I'm still getting a React development warning in the console because MDX is nesting \<div\> inside \<p\>. Because its a development warning, it won't ever get displayed in production. It's still annoying because it takes up unnecessary space in the console.

It's going to be difficult to get rid of the underlying problem because MDX converts blocks of plaintext into \<p\>'s automatically. I think there's a way to silence the warning on the development side by overriding console.warn() and filtering out that warning, but wasn't able to get it working. 