### PR TITLE
OFAST-162 Problem Table Solve Status

### DIFF
--- a/src/components/ProblemProvider.tsx
+++ b/src/components/ProblemProvider.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import buildPath from '../path'
 import Problems from '../objects/Problems'
+import { useSelector } from 'react-redux'
+import { RootState } from '../store'
 
 const ProblemsContext = createContext<Problems>(new Problems([]))
 
@@ -11,6 +13,7 @@ interface ProblemProviderProps {
 export const ProblemProvider: React.FC<ProblemProviderProps> = ({
   children,
 }) => {
+  const user = useSelector((state: RootState) => state.user)
   const [problemsObject, setProblemsObject] = useState<Problems>(
     new Problems([]),
   )
@@ -22,7 +25,55 @@ export const ProblemProvider: React.FC<ProblemProviderProps> = ({
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         })
-        const result = await response.json()
+        let result = await response.json()
+        const problemIDs = result.map(
+          (problemMetadata) => problemMetadata.problemID,
+        )
+
+        if (user.signedIn) {
+          const solveStatusResponse = await fetch(
+            buildPath('/getSubmissions'),
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                problemIds: problemIDs,
+                uid: user.id,
+                isBrief: true,
+              }),
+            },
+          )
+
+          const solveStatusResult = await solveStatusResponse.json()
+          const problemIDtoSolveStatus = {}
+
+          solveStatusResult.submissionsPerProblem.forEach((problemStatus) => {
+            const pid = problemStatus.problemId
+            const isSubmitted = problemStatus.isSubmitted
+            const isAccepted = problemStatus.isAccepted
+
+            problemIDtoSolveStatus[pid] = isSubmitted
+              ? isAccepted
+                ? 'solved'
+                : 'wrong'
+              : 'unsolved'
+          })
+
+          result = result.map((problem) => {
+            return {
+              status: problemIDtoSolveStatus[problem.problemID],
+              ...problem,
+            }
+          })
+        } else {
+          result = result.map((problem) => {
+            return {
+              status: 'unsolved',
+              ...problem,
+            }
+          })
+        }
+
         setProblemsObject(new Problems(result))
       } catch (error) {
         console.error('Error fetching problems: ', error)
@@ -30,7 +81,7 @@ export const ProblemProvider: React.FC<ProblemProviderProps> = ({
     }
 
     fetchProblems()
-  }, [])
+  }, [user.id])
 
   return (
     <ProblemsContext.Provider value={problemsObject}>

--- a/src/components/ProblemsTable.tsx
+++ b/src/components/ProblemsTable.tsx
@@ -100,7 +100,17 @@ const getTableValue = (columnID: string, problemMetaData: ProblemMetaData) => {
 export default function StickyHeadTable() {
   const problemsObject = useProblemsObject()
   const [pageNumber, setPageNumber] = React.useState(1)
+  const [problems, setProblems] = React.useState<ProblemMetaData[]>([])
   const rowsPerPage = 10
+
+  React.useEffect(() => {
+    setProblems(
+      problemsObject.getProblemMetaDataFromRange(
+        (pageNumber - 1) * rowsPerPage,
+        pageNumber * rowsPerPage,
+      ),
+    )
+  }, [pageNumber, problemsObject])
 
   const handleChangePage = (_event: unknown, newPageNumber: number) => {
     setPageNumber(newPageNumber)
@@ -133,28 +143,23 @@ export default function StickyHeadTable() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {problemsObject
-              .getProblemMetaDataFromRange(
-                (pageNumber - 1) * rowsPerPage,
-                pageNumber * rowsPerPage,
+            {problems.map((row: ProblemMetaData) => {
+              return (
+                <TableRow hover key={row.title}>
+                  {columns.map((column) => {
+                    return (
+                      <TableCell
+                        key={column.id}
+                        align={column.align}
+                        style={{ overflow: 'hidden ' }}
+                      >
+                        {getTableValue(column.id, row)}
+                      </TableCell>
+                    )
+                  })}
+                </TableRow>
               )
-              .map((row: ProblemMetaData) => {
-                return (
-                  <TableRow hover key={row.title}>
-                    {columns.map((column) => {
-                      return (
-                        <TableCell
-                          key={column.id}
-                          align={column.align}
-                          style={{ overflow: 'hidden ' }}
-                        >
-                          {getTableValue(column.id, row)}
-                        </TableCell>
-                      )
-                    })}
-                  </TableRow>
-                )
-              })}
+            })}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/objects/Problems.ts
+++ b/src/objects/Problems.ts
@@ -1,5 +1,6 @@
 export type Problem = {
   problemID: string
+  status: string
   title: string
   text: string
   problem: string
@@ -32,24 +33,13 @@ export default class Problems {
     this.problemMetaData = this.problems.map((problem) => {
       const metaData: ProblemMetaData = {
         problemID: problem.problemID,
-        status: this.getFakeStatus(problem),
+        status: problem.status,
         title: problem.title,
         tags: problem.tags,
       }
 
       return metaData
     })
-  }
-
-  public getFakeStatus(problem: Problem) {
-    let sum = 0
-    for (let i = 0; i < problem.title.length; i++) {
-      sum += problem.title.charCodeAt(i)
-    }
-
-    const status = ['solved', 'wrong', 'unsolved']
-
-    return status[sum % status.length]
   }
 
   public searchProblems(text: string, maxCount: number): Problem[] {

--- a/src/objects/__tests__/Problems.test.ts
+++ b/src/objects/__tests__/Problems.test.ts
@@ -4,6 +4,7 @@ import Problems, { Problem } from '../Problems'
 const mockProblems: Problem[] = [
   {
     problemID: '1',
+    status: 'solved',
     title: 'Problem One',
     text: 'Description for Problem One',
     problem: 'Problem statement for One',
@@ -21,11 +22,6 @@ describe('Problems Class Tests', () => {
 
   beforeEach(() => {
     problemsInstance = new Problems(mockProblems)
-  })
-
-  test('getFakeStatus returns correct status', () => {
-    const fakeStatus = problemsInstance.getFakeStatus(mockProblems[0])
-    expect(['solved', 'wrong', 'unsolved']).toContain(fakeStatus)
   })
 
   test('searchProblems returns correct results', () => {


### PR DESCRIPTION
- Updated the ProblemProvider to fetch the problem solve statuses and display the appropriate color on the table.
- The statuses only update on page refresh or user.id change. So, we'll have to make it update on problem submission, once that is set up. 

https://github.com/ofast-team/frontend/assets/46213673/3d897aa8-c5d4-404a-a4db-310649a98416