### PR TITLE
OFAST-160 Share showTOC state between lesson blocks

### DIFF
--- a/src/components/LessonPage/LessonBlock.tsx
+++ b/src/components/LessonPage/LessonBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { Box, IconButton, Tooltip } from '@mui/material'
 import TocIcon from '@mui/icons-material/Toc'

--- a/src/components/LessonPage/LessonBlock.tsx
+++ b/src/components/LessonPage/LessonBlock.tsx
@@ -12,10 +12,16 @@ import MDX from '../../components/MDXRenderer'
 interface LessonBlockProps {
   path: string
   headers: TOCHeader[]
+  showTOC: boolean
+  toggleTOC: () => void
 }
 
-export default function LessonBlock({ path, headers }: LessonBlockProps) {
-  const [showTOC, setShowTOC] = useState<boolean>(true)
+export default function LessonBlock({
+  path,
+  headers,
+  showTOC,
+  toggleTOC,
+}: LessonBlockProps) {
   const mdx = <MDX path={path} />
 
   return (
@@ -70,7 +76,7 @@ export default function LessonBlock({ path, headers }: LessonBlockProps) {
               left: '220px',
               zIndex: 1,
             }}
-            onClick={() => setShowTOC((showTOC) => !showTOC)}
+            onClick={toggleTOC}
           >
             <TocIcon color="primary" />
           </IconButton>
@@ -94,7 +100,7 @@ export default function LessonBlock({ path, headers }: LessonBlockProps) {
               transform: 'translateY(-50%)',
               zIndex: 1,
             }}
-            onClick={() => setShowTOC((showTOC) => !showTOC)}
+            onClick={toggleTOC}
           >
             <TocIcon color="primary" />
           </IconButton>

--- a/src/pages/LessonPage.tsx
+++ b/src/pages/LessonPage.tsx
@@ -37,6 +37,7 @@ export default function LessonPage() {
   const blockFilenames: string[] =
     'files' in lessons[lesson] ? lessons[lesson].files : []
   const [tocHeaders, setTocHeaders] = useState<TOCHeader[]>([])
+  const [showTOC, setShowTOC] = useState<boolean>(true)
 
   if (!(lesson in lessons)) {
     return <Navigate to="/learn" replace />
@@ -57,6 +58,8 @@ export default function LessonPage() {
       key={lessonFilename}
       path={'/lessons/' + lesson + '/' + lessonFilename}
       headers={tocHeaders}
+      showTOC={showTOC}
+      toggleTOC={() => setShowTOC((curState) => !curState)}
     />
   ))
 


### PR DESCRIPTION
- Moved the showTOC state to its parent component so the TOC stays hidden/shown when moving between lesson blocks

https://github.com/ofast-team/frontend/assets/46213673/7c23ff00-1b00-4404-a89f-b755c32a3e2b

