### PR TITLE
OFAST-171 TOC Sticky

### DIFF
--- a/src/components/LessonPage/LessonBlock.tsx
+++ b/src/components/LessonPage/LessonBlock.tsx
@@ -64,7 +64,7 @@ export default function LessonBlock({
             : 'none',
           pt: '7px',
           verticalAlign: 'top',
-          position: 'relative',
+          position: 'fixed',
         }}
       >
         <TableOfContents headers={headers} />
@@ -73,7 +73,7 @@ export default function LessonBlock({
             sx={{
               position: 'absolute',
               top: '2px',
-              left: '220px',
+              left: '180px',
               zIndex: 1,
             }}
             onClick={toggleTOC}


### PR DESCRIPTION
- TOC stays on screen when scrolling down the lesson page
- Moved the toggle button closer to the TOC header

https://github.com/ofast-team/frontend/assets/46213673/ec7d6d5e-5d68-4538-a2f8-78e161f3e74d