### PR TITLE
OFAST-186 Playground Catch Runtime Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
+        "react-error-boundary": "^4.0.13",
         "react-firebase-hooks": "^5.1.1",
         "react-intersection-observer": "^9.8.1",
         "react-redux": "^8.1.3",
@@ -21966,6 +21967,17 @@
       },
       "peerDependencies": {
         "react": ">= 16.8 || 18.0.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-error-overlay": {
@@ -44119,6 +44131,14 @@
         "attr-accept": "^2.2.2",
         "file-selector": "^0.6.0",
         "prop-types": "^15.8.1"
+      }
+    },
+    "react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
+    "react-error-boundary": "^4.0.13",
     "react-firebase-hooks": "^5.1.1",
     "react-intersection-observer": "^9.8.1",
     "react-redux": "^8.1.3",

--- a/src/components/PlaygroundPage/MDXTab.tsx
+++ b/src/components/PlaygroundPage/MDXTab.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
-import { Typography, TextField } from '@mui/material'
-
+import { Typography, TextField, Alert } from '@mui/material'
+import { ErrorBoundary } from 'react-error-boundary'
 import MDX from '../MDXRenderer'
 
 export default function MDXTab() {
   const [text, setText] = React.useState<string>('')
+  const [isError, setIsError] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    setIsError(false)
+  }, [text])
 
   return (
     <>
@@ -23,7 +28,16 @@ export default function MDXTab() {
         color="primary"
         component="span"
       >
-        <MDX value={text} />
+        {!isError ? (
+          <ErrorBoundary
+            fallbackRender={() => <></>}
+            onError={() => setIsError(true)}
+          >
+            <MDX value={text} />
+          </ErrorBoundary>
+        ) : (
+          <Alert severity="error">Runtime Error</Alert>
+        )}
       </Typography>
     </>
   )


### PR DESCRIPTION
- MDX Playground now catches runtime errors
- Had to use the error boundary in a possibly unconventional way because the error boundary wasn't resetting when the error was fixed
- Not displaying specific error info because it contains code references

Dev still shows big red overlay:

https://github.com/ofast-team/frontend/assets/46213673/1b0274f3-2e8e-40cc-aa39-1a746040f3ed

Prod build doesn't show it (only in console):

https://github.com/ofast-team/frontend/assets/46213673/39977c06-eb0a-4301-95c8-c4c87321937e

