### PR TITLE
Improve load on submit

### DIFF
--- a/src/components/ProblemPage/ProblemBlockCards.tsx
+++ b/src/components/ProblemPage/ProblemBlockCards.tsx
@@ -123,6 +123,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
     setIsSubmitting(true)
     if (!problemCodeFile || !codeLang) {
       setErrorText('Please select a file to upload!')
+      setIsSubmitting(false)
       return
     }
     fetch(buildPath('/submit'), {
@@ -148,6 +149,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
         navigate(`/submissions/${token}`)
       })
       .catch((error: Error) => {
+        setIsSubmitting(false)
         setErrorText(error.message)
       })
   }
@@ -200,9 +202,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
                     onChange={handleFileChange}
                   />
                 </label>
-                <Box
-                  display="flex"
-                >
+                <Box display="flex">
                   <Box
                     display="flex"
                     position="relative"
@@ -217,11 +217,8 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
                       Submit
                     </Button>
                     {isSubmitting && (
-                      <Box
-                        position="absolute"
-                        left="90px"
-                      >
-                        <CircleLoadAnimation/>
+                      <Box position="absolute" left="90px">
+                        <CircleLoadAnimation />
                       </Box>
                     )}
                   </Box>

--- a/src/components/ProblemPage/ProblemBlockCards.tsx
+++ b/src/components/ProblemPage/ProblemBlockCards.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { Verdict, verdictInfo } from '../../utils/verdict'
 import { Problem } from '../../objects/Problems'
+import CircleLoadAnimation from '../CircleLoadAnimation'
 
 interface Submission {
   submissionID: string
@@ -57,6 +58,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
   const [problemCodeFile, setProblemCodeFile] = useState<string>('')
   const [codeLang, setCodeLang] = useState<string>('')
   const [errorText, setErrorText] = useState<string>('')
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   useEffect(() => {
     const fetchSubmissions = async () => {
@@ -118,6 +120,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
   }
 
   const submitCode = () => {
+    setIsSubmitting(true)
     if (!problemCodeFile || !codeLang) {
       setErrorText('Please select a file to upload!')
       return
@@ -141,6 +144,7 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
       })
       .then((data) => {
         const token = data.token
+        setIsSubmitting(false)
         navigate(`/submissions/${token}`)
       })
       .catch((error: Error) => {
@@ -196,9 +200,32 @@ export default function ProblemBlockCards({ problem }: { problem: Problem }) {
                     onChange={handleFileChange}
                   />
                 </label>
-                <Button variant="contained" onClick={submitCode}>
-                  Submit
-                </Button>
+                <Box
+                  display="flex"
+                >
+                  <Box
+                    display="flex"
+                    position="relative"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <Button
+                      variant="contained"
+                      onClick={submitCode}
+                      disabled={isSubmitting}
+                    >
+                      Submit
+                    </Button>
+                    {isSubmitting && (
+                      <Box
+                        position="absolute"
+                        left="90px"
+                      >
+                        <CircleLoadAnimation/>
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
               </Box>
             ) : (
               <Box>

--- a/src/components/SubmitPage/SubmitFields.tsx
+++ b/src/components/SubmitPage/SubmitFields.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, SetStateAction } from 'react'
 import { Box, Button, Container, TextField } from '@mui/material'
 import PlayIcon from '@mui/icons-material/PlayArrow'
+import CircleLoadAnimation from '../CircleLoadAnimation'
 
 interface SubmitFieldsProps {
   timeLimit: number
@@ -8,6 +9,7 @@ interface SubmitFieldsProps {
   setTimeLimit: Dispatch<SetStateAction<number>>
   setMemoryLimit: Dispatch<SetStateAction<number>>
   handleSubmit: () => void
+  isSubmitting: boolean
 }
 
 export default function SubmitFields({
@@ -16,6 +18,7 @@ export default function SubmitFields({
   setTimeLimit,
   setMemoryLimit,
   handleSubmit,
+  isSubmitting,
 }: SubmitFieldsProps) {
   return (
     <Container
@@ -56,15 +59,32 @@ export default function SubmitFields({
           alignItems: 'center',
         }}
       >
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleSubmit}
-          endIcon={<PlayIcon fontSize="large" />}
-          size="large"
+        <Box
+          sx={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
         >
-          RUN
-        </Button>
+          {isSubmitting && (
+            <Box sx={{ position: 'absolute', right: '100px' }}>
+              <CircleLoadAnimation />
+            </Box>
+          )}
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => {
+              handleSubmit()
+            }}
+            endIcon={<PlayIcon fontSize="large" />}
+            size="medium"
+            disabled={isSubmitting}
+          >
+            RUN
+          </Button>
+        </Box>
       </Box>
     </Container>
   )

--- a/src/pages/SubmitPage.tsx
+++ b/src/pages/SubmitPage.tsx
@@ -26,11 +26,14 @@ export default function SubmitPage() {
   const [outputArray, setOutputArray] = useState<string[]>([])
   const [timeLimit, setTimeLimit] = useState<number>(1)
   const [memoryLimit, setMemoryLimit] = useState<number>(1024)
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
 
   const fetchSubmit = () => {
+    setIsSubmitting(true)
     setErrorText('')
     if (!codeBase64 || !codeLang || !inputArray.length || !outputArray.length) {
       setErrorText('Upload code file and test folder!')
+      setIsSubmitting(false)
       return
     }
 
@@ -55,16 +58,14 @@ export default function SubmitPage() {
         throw Error(res.statusText)
       })
       .then((data) => {
+        setIsSubmitting(false)
         const token = data.token
         navigate(`/submissions/${token}`)
       })
       .catch((error: Error) => {
+        setIsSubmitting(false)
         setErrorText(error.message)
       })
-  }
-
-  const handleSubmit = () => {
-    fetchSubmit()
   }
 
   return (
@@ -78,7 +79,8 @@ export default function SubmitPage() {
         memoryLimit={memoryLimit}
         setTimeLimit={setTimeLimit}
         setMemoryLimit={setMemoryLimit}
-        handleSubmit={handleSubmit}
+        handleSubmit={fetchSubmit}
+        isSubmitting={isSubmitting}
       />
 
       <Box


### PR DESCRIPTION
"Did it go through?" "I'm going to try again." "Why are there 3 submissions? I only submitted once."

The folks who've tested ofast so far have spammed submissions because it wasn't obvious that their original one was loading.
I eliminated this by disabling the submit button while the API is turning it in to Judge0, and showing a loading animation until the submission ID comes back.

[AwesomeScreenshot-4_13_2024,8 23 24PM.webm](https://github.com/ofast-team/frontend/assets/51721851/5412f2a8-46a5-474d-8cf3-0bf0e69b6708)
